### PR TITLE
libs-base patch: fix DNSServiceRef leak in NSNetService resolve

### DIFF
--- a/Library/Patches/libs-base/gsmdnsnetservices-resolve-ref-leak.patch
+++ b/Library/Patches/libs-base/gsmdnsnetservices-resolve-ref-leak.patch
@@ -1,0 +1,64 @@
+--- a/Source/GSMDNSNetServices.m	2026-08-28 00:29:04
++++ b/Source/GSMDNSNetServices.m	2026-08-28 00:29:04
+@@ -129,6 +129,11 @@
+   
+   BOOL			 isPublishing,		// true if publishing service
+                          isMonitoring;		// true if monitoring
++
++  void			*staleRef;
++    // A DNSServiceRef that has been replaced in _netService and is waiting
++    // to be deallocated from outside a dns_sd callback. See -loop: and
++    // resolverCallback below.
+ } Service;
+ 
+ typedef struct _Monitor		// The actual NSNetServiceMonitor
+@@ -934,6 +939,12 @@
+ 	DESTROY(service->timer);
+       }
+     
++    if (service->staleRef)
++      {
++	DNSServiceRefDeallocate((DNSServiceRef) service->staleRef);
++	service->staleRef = NULL;
++      }
++    
+     if (_netService)
+       {
+ 	DNSServiceRefDeallocate(_netService);
+@@ -1045,6 +1056,20 @@
+ 	  service->interfaceIndex = interfaceIndex;
+ 	  
+ 	  service->timer = nil;
++	  
++	  /* DNSServiceQueryRecord() below writes a NEW DNSServiceRef over
++	     _netService, which still holds the ref created by
++	     DNSServiceResolve(). Without this, that ref becomes unreachable
++	     and leaks a connection to the mDNS daemon on every successful
++	     resolve -- -stop, -dealloc and every error path can only free
++	     whatever is currently in the ivar.
++	     
++	     It cannot simply be deallocated here: this callback runs inside
++	     DNSServiceProcessResult() for that very ref, and freeing it
++	     mid-callback would pull the socket out from under the library as
++	     it unwinds. Hand it to -loop:, which frees it at the top of the
++	     next poll, outside any callback. */
++	  service->staleRef = (void *) _netService;
+ 	  
+ 	  // Prepare query for A and/or AAAA record
+ 	  errorCode = DNSServiceQueryRecord((DNSServiceRef *) &_netService,
+@@ -1423,6 +1448,15 @@
+   struct timeval	tout = { 0 };
+   fd_set		set;
+   DNSServiceErrorType	err = kDNSServiceErr_NoError;
++  Service		*svc = (Service *) _reserved;
++  
++  /* Free the resolve ref that resolverCallback replaced. Safe here: we
++     are not inside a dns_sd callback yet. */
++  if (svc != NULL && svc->staleRef != NULL)
++    {
++      DNSServiceRefDeallocate((DNSServiceRef) svc->staleRef);
++      svc->staleRef = NULL;
++    }
+   
+   sock = DNSServiceRefSockFD(_netService);
+   


### PR DESCRIPTION
Adds `Library/Patches/libs-base/gsmdnsnetservices-resolve-ref-leak.patch`.

## The bug

GNUstep's `NSNetService` leaks one connection to `mDNSResponder` on **every
successful resolve**, and no caller can prevent it.

`-resolveWithTimeout:` opens a ref with `DNSServiceResolve()` into `_netService`
(`GSMDNSNetServices.m:1972`). When the SRV reply arrives, `resolverCallback`
passes `&_netService` to `DNSServiceQueryRecord()` at `:1050` to fetch the
A/AAAA records — dns_sd writes a **new** ref over the ivar while the resolve ref
is still live. That pointer is now unreachable, and `-cleanup` (`:939`), `-stop`,
`-dealloc` and every error path can only free whatever is currently in the ivar.

Each `DNSServiceRef` holds its own unix socket to the daemon, so this strands one
descriptor per resolve, permanently.

## Why the obvious fix is wrong

Deallocating at the point of replacement looks right and is not: `resolverCallback`
runs **inside** `DNSServiceProcessResult()` for that very ref, so freeing it
mid-callback pulls the socket out from under the library as it unwinds.

This patch stashes the old ref in the private `Service` struct and frees it at the
top of the next `-loop:` poll, which is outside any dns_sd callback. `-cleanup`
also drains it, for objects torn down before the next poll.

## Evidence

Measured on a NextBSD VM with two Bonjour hosts on the LAN:

- 12 resolves in 30s produced **24** new daemon connections — 2 per resolve, the
  leaked resolve ref plus the query ref.
- 144 connections opened against **16** cleanup events since boot.
- Under a NextBSD daemon bug that drove continuous browser callbacks
  (nextbsd-userland#67, since fixed), this reached **~1 leaked descriptor per
  second** — 259 → 299 over 40 seconds — and would have exhausted mDNSResponder
  in roughly 32 hours, taking all Bonjour down with it.

The Avahi backend in the same tree (`GSAvahiNetServiceBrowser.m:453-488`) handles
this correctly and never overwrites a live handle — useful as a reference.

## Not fixed here

Two adjacent defects, deliberately left alone:

1. `resolverCallback` also does `service->timer = nil` at `:1047` on a **retained,
   run-loop-registered** timer without invalidating it, so the `NSNetService`
   never reaches `-dealloc`. Fixing that in isolation would *stop the polling that
   drives the query*, because the replacement timer built at `:1062-1067` is
   autoreleased and never added to a run loop. It needs a larger change than a
   carried patch should make.
2. The `-resolveWithTimeout:` timeout timer (`:1958-1969`) is created with
   `-initWithFireDate:` and never scheduled, so `-stopResolving:` never runs and
   the documented timeout contract is not implemented.

## Testing status

**Built and run by nobody yet — this needs your build before merge.** I verified:

- `patch -p1 --dry-run` applies cleanly against the pinned `libs-base` checkout.
- the reverse dry-run also succeeds, so `patch.sh`'s already-applied detection
  works and re-running `make patch` is safe.

I could not compile GNUstep in this session, so the change is source-reasoned
only. The specific risk to watch is a double-free if any path frees `staleRef`
and then reaches `-cleanup` before it is nulled — it is set to `NULL` at both
free sites, but a second pair of eyes on that is worth having.

Upstream is `gnustep/libs-base`; this is carried here until it lands there.
